### PR TITLE
Bugfix/interaction timing

### DIFF
--- a/include/fluid/fluid.h
+++ b/include/fluid/fluid.h
@@ -94,6 +94,11 @@ struct FluidConfiguration {
      * @brief Use ground_truth data for interact operation.
      */
     const float interact_max_acc;  
+
+    /**
+     * @brief max angle ardupilot parameter for the travel operation.
+     */
+    const float travel_max_angle;  
 };
 
 /**

--- a/include/fluid/mast.h
+++ b/include/fluid/mast.h
@@ -13,8 +13,6 @@
 #define SAVE_PITCH_TIME 15
 #define SAVE_PITCH_FREQ 4 //Todo, may not work with whatever frequency. 6Hz looks weird
 
-#define TIME_WINDOW_INTERACTION 1.0
-
 /**
  * @brief Represent the mast of Mission 9
  */
@@ -165,6 +163,13 @@ class Mast{
      * @return float mast fixed yaw
      */
     float get_yaw();
+
+    /**
+     * @brief Set the period of the mast
+     * 
+     * @param period from ekf
+     */
+    void set_period(float period);
 
     /**
      * @brief Get the estimated period of the mast

--- a/include/fluid/operations/travel_operation.h
+++ b/include/fluid/operations/travel_operation.h
@@ -17,14 +17,16 @@ class TravelOperation : public MoveOperation {
      * @brief Sets up the travel operation.
      *
      * @param path List of setpoints.
-     * @param 20 is the travel speed in [m/s].
+     * @param 100 is the travel speed in [m/s].
      * @param 2 means that setpoints count as visited within 2 [m].
      * @param 3 is the maximum speed the drone can have in the setpoint
      *          to mark it as visited [m/s].
-     * @param 45 is the maximum tilt angle of the drone during movement [deg].
+     * @param max_angle is the maximum tilt angle of the drone during movement [deg]. 
+     *                  This is set in the base.launch file.
      */
     TravelOperation(const std::vector<geometry_msgs::Point>& path)
-        : MoveOperation(OperationIdentifier::TRAVEL, path, 100, 2, 3, 70) {}
+        : MoveOperation(OperationIdentifier::TRAVEL, path, 100, 2, 3, Fluid::getInstance().configuration.travel_max_angle) {}
+        
 };
 
 #endif

--- a/include/fluid/operations/travel_operation.h
+++ b/include/fluid/operations/travel_operation.h
@@ -24,7 +24,7 @@ class TravelOperation : public MoveOperation {
      * @param 45 is the maximum tilt angle of the drone during movement [deg].
      */
     TravelOperation(const std::vector<geometry_msgs::Point>& path)
-        : MoveOperation(OperationIdentifier::TRAVEL, path, 20, 2, 3, 45) {}
+        : MoveOperation(OperationIdentifier::TRAVEL, path, 100, 2, 3, 70) {}
 };
 
 #endif

--- a/launch/base.launch
+++ b/launch/base.launch
@@ -19,6 +19,8 @@
   <arg name="Kvy"                                     default="3.141608"/>
   <arg name="interaction_max_vel"                     default="0.30"/>
   <arg name="interaction_max_acc"                     default="0.23"/>
+
+  <arg name="travel_max_angle"                          default="70"/>
   
 
   <node name="fluid" pkg="fluid" type="fluid" output="screen"> 
@@ -41,6 +43,8 @@
     <param name="Kvy"                                 value="$(arg Kvy)"/>
     <param name="interaction_max_vel"                 value="$(arg interaction_max_vel)"/>
     <param name="interaction_max_acc"                 value="$(arg interaction_max_acc)"/>
+
+    <param name="travel_max_angle"                 value="$(arg travel_max_angle)"/>
 
   </node>
 

--- a/src/mast.cpp
+++ b/src/mast.cpp
@@ -56,11 +56,6 @@ void Mast::search_period(double pitch){
                 //We have not found a new minimum for 0.5sec. The last one found it the correct one.
                 m_last_min_pitch = m_current_extremum;
                 m_lookForMin = false;
-                if(!m_time_last_max_pitch.isZero()){ //We have already found a min before
-                    m_period = 2* (m_time_last_min_pitch - m_time_last_max_pitch).toSec();
-                    if(m_SHOW_PRINTS)
-                        ROS_INFO_STREAM("period from min = " << m_period);
-                }
             }
         }
     }
@@ -74,11 +69,6 @@ void Mast::search_period(double pitch){
                 //We have not found a new maximum for 0.5sec. The last one found it the correct one.
                 m_last_max_pitch = m_current_extremum;
                 m_lookForMin = true;
-                if(!m_time_last_min_pitch.isZero()){ //We have already found a min before
-                    m_period = 2 * (m_time_last_max_pitch - m_time_last_min_pitch).toSec();
-                    if(m_SHOW_PRINTS)
-                        ROS_INFO_STREAM("period from max = " << m_period);
-                }
             }
         }
     }
@@ -110,6 +100,10 @@ float Mast::time_to_max_pitch(){
 
 float Mast::get_yaw(){
     return m_fixed_yaw;
+}
+
+void Mast::set_period(float period){
+    m_period = period;
 }
 
 float Mast::get_period(){

--- a/src/nodes/main.cpp
+++ b/src/nodes/main.cpp
@@ -14,7 +14,7 @@ int main(int argc, char** argv) {
 
     ros::NodeHandle node_handle;
     const std::string prefix = ros::this_node::getName() + "/";
-    int refresh_rate;
+    int refresh_rate, travel_max_angle;
     bool ekf, use_perception, should_auto_arm, should_auto_offboard, interaction_show_prints;
     float distance_completion_threshold, velocity_completion_threshold, default_height;
     float interact_max_vel, interact_max_acc;
@@ -80,6 +80,9 @@ int main(int argc, char** argv) {
         exitAtParameterExtractionFailure(prefix + "interaction_max_acc");
     }
 
+    if (!node_handle.getParam(prefix + "travel_max_angle", travel_max_angle)) {
+        exitAtParameterExtractionFailure(prefix + "travel_max_angle");
+    }
     FluidConfiguration configuration{ekf,
                                     use_perception,
                                     refresh_rate,
@@ -91,7 +94,8 @@ int main(int argc, char** argv) {
                                     LQR_gains,
                                     interaction_show_prints,
                                     interact_max_vel,
-                                    interact_max_acc
+                                    interact_max_acc,
+                                    travel_max_angle
                                     };
 
     Fluid::initialize(configuration);

--- a/src/operations/explore_operation.cpp
+++ b/src/operations/explore_operation.cpp
@@ -11,7 +11,7 @@
 #include "util.h"
 
 ExploreOperation::ExploreOperation(const std::vector<geometry_msgs::Point>& path, const geometry_msgs::Point& point_of_interest)
-    : MoveOperation(OperationIdentifier::EXPLORE, path, 0.5, 0.5, 1, 15),
+    : MoveOperation(OperationIdentifier::EXPLORE, path, 1, 0.5, 1, 4),
       obstacle_avoidance_path_publisher(node_handle.advertise<ascend_msgs::Path>("/obstacle_avoidance/path", 10)),
       obstacle_avoidance_path_subscriber(
           node_handle.subscribe("/obstacle_avoidance/corrected_path", 10, &ExploreOperation::pathCallback, this)),

--- a/src/operations/interact_operation.cpp
+++ b/src/operations/interact_operation.cpp
@@ -14,10 +14,11 @@
 //A list of parameters for the user
 #define MAST_INTERACT true //safety feature to avoid going at close proximity to the mast and set the FH
 #define MAX_DIST_FOR_CLOSE_TRACKING     1.0 //max distance from the mast before activating close tracking
-    
+#define TIME_WINDOW_INTERACTION 1.0 // window within the drone is allowed to go to the OVER state    
 
 // Important distances
 #define DIST_FH_DRONE_CENTRE_X   0.42 // 0.5377
+#define DIST_FH_DRONE_CENTRE_Y   0.02 // 0.5377
 #define DIST_FH_DRONE_CENTRE_Z  -0.4914 //-0.3214
 
 #define SAVE_DATA   true
@@ -57,7 +58,7 @@ InteractOperation::InteractOperation(const float& fixed_mast_yaw, const float& o
     //Choose an initial offset. It is the offset for the approaching state.
     //the offset is set in the frame of the mast:    
     desired_offset.x = offset;     //forward
-    desired_offset.y = 0.03;     //left
+    desired_offset.y = DIST_FH_DRONE_CENTRE_Y;     //left
     desired_offset.z = DIST_FH_DRONE_CENTRE_Z+0.03;    //up
 
     }
@@ -142,6 +143,7 @@ void InteractOperation::ekfModulePoseCallback(
 void InteractOperation::ekfStateVectorCallback(
                 const mavros_msgs::DebugValue ekf_state) {
     mast.search_period(ekf_state.data[0]); //the first element is the pitch
+    mast.set_period(2*M_PI/ekf_state.data[4]);
 }
 
 void InteractOperation::modulePoseCallback(
@@ -167,7 +169,7 @@ void InteractOperation::FaceHuggerCallback(const std_msgs::Bool released){
         faceHugger_is_set = true;
 
         desired_offset.x = 2.0;   //forward
-        desired_offset.y = 0.03;    //left
+        desired_offset.y = DIST_FH_DRONE_CENTRE_Y;    //left
         desired_offset.z = DIST_FH_DRONE_CENTRE_Z - 0.3;   //up
         transition_state.state.position.z = desired_offset.z;
         transition_state.cte_acc = MAX_ACCEL*3;
@@ -358,7 +360,7 @@ float InteractOperation::estimate_time_to_mast()
 {
     // Estimation of the time it takes to go from current position to interaction point
     float dist = transition_state.state.position.x - DIST_FH_DRONE_CENTRE_X; //assuming that the drone is always accurate
-    float dist_acc_decc = MAX_VEL*MAX_VEL/MAX_ACCEL;
+    float dist_acc_decc = Util::sq(MAX_VEL)/MAX_ACCEL;
     if (dist < dist_acc_decc)
         return 2.0 * sqrt(2.0*dist/MAX_ACCEL);
     else
@@ -400,18 +402,16 @@ void InteractOperation::tick() {
                     //Todo, we may want to judge the velocity in stead of having a time to completion
                     if (completion_count < ceil(TIME_TO_COMPLETION * (float)rate_int) )
                         completion_count++;
-                    else if(mast.time_to_max_pitch() !=-1){// we don't know the period of the mast yet
+                    else {
                         //We consider that if the drone is ready at some point, it will 
-                        // remain ready until it is time to try
+                        //remain ready until it is time to try
+                        ROS_INFO_STREAM(ros::this_node::getName().c_str()
+                                        << ": " << "Approaching -> Ready");
+
                         completion_count = 0;
-                    
-                        float time_to_wait = mast.time_to_max_pitch()-estimate_time_to_mast();
-                        if(time_to_wait < -TIME_WINDOW_INTERACTION)
-                            time_to_wait+=mast.get_period();
                         ROS_INFO_STREAM(ros::this_node::getName().c_str() 
-                                << ": Control ready to set the FaceHugger. Waiting for the best opportunity"
-                                << "\nEstimated waiting time before go: "
-                                << time_to_wait);
+                                << ": Control ready to set the FaceHugger."
+                                << " Waiting for the best opportunity");
                         interaction_state = InteractionState::READY;   
                         desired_offset.x = MAX_DIST_FOR_CLOSE_TRACKING;             
                     }
@@ -423,15 +423,6 @@ void InteractOperation::tick() {
         }
         case InteractionState::READY: {
             //The drone is ready, we just have to wait for the best moment to go!
-            float time_to_wait = mast.time_to_max_pitch()-estimate_time_to_mast();
-            if(time_to_wait < -TIME_WINDOW_INTERACTION)
-                time_to_wait+=mast.get_period();
-
-            if (SHOW_PRINTS and time_cout%(rate_int/2)==0) {
-                ROS_INFO_STREAM("READY; "
-                        << "Estimated waiting time before go: "
-                        << time_to_wait);
-            }
             if(!close_tracking_is_set and (transition_state.finished_bitmask & 0x7) == 0x7){
                 ROS_INFO_STREAM(ros::this_node::getName().c_str() 
                         << ": Turning on close tracking");
@@ -449,20 +440,31 @@ void InteractOperation::tick() {
                     close_tracking_is_ready = true;
                 }
             }
-
-            if( abs(time_to_wait) <= TIME_WINDOW_INTERACTION and close_tracking_is_ready)
-            { //We are in the good window to set the faceHugger
-                interaction_state = InteractionState::OVER;
-                ROS_INFO_STREAM(ros::this_node::getName().c_str()
-                            << ": " << "Approaching -> Over");
-                desired_offset.x = DIST_FH_DRONE_CENTRE_X;  //forward
-                desired_offset.y = 0.03;   //left
-                desired_offset.z = DIST_FH_DRONE_CENTRE_Z+0.03; //up
-                transition_state.cte_acc = MAX_ACCEL;
-                transition_state.max_vel = MAX_VEL;
-                transition_state.finished_bitmask = 0x0;
+            if(mast.time_to_max_pitch() !=-1){ //we don't konw it yet
+                float time_to_wait = mast.time_to_max_pitch()-estimate_time_to_mast();
+//              printf("t_2max_pitch %f\t t_2mast %f\tt_wait %f\n",
+//                          mast.time_to_max_pitch(), estimate_time_to_mast(), time_to_wait);
+                if(time_to_wait < -TIME_WINDOW_INTERACTION){
+                    time_to_wait+=mast.get_period();
+                }
+                if (SHOW_PRINTS and time_cout%(rate_int/2)==0) {
+                    ROS_INFO_STREAM("READY; "
+                            << "Estimated waiting time before go: "
+                            << time_to_wait);
+                }
+                if( close_tracking_is_ready and (abs(time_to_wait) <= TIME_WINDOW_INTERACTION) )
+                { //We are in the good window to set the faceHugger
+                    interaction_state = InteractionState::OVER;
+                    ROS_INFO_STREAM(ros::this_node::getName().c_str()
+                                << ": " << "Ready -> Over");
+                    desired_offset.x = DIST_FH_DRONE_CENTRE_X;  //forward
+                    desired_offset.y = DIST_FH_DRONE_CENTRE_Y;   //left
+                    desired_offset.z = DIST_FH_DRONE_CENTRE_Z+0.03; //up
+                    transition_state.cte_acc = MAX_ACCEL;
+                    transition_state.max_vel = MAX_VEL;
+                    transition_state.finished_bitmask = 0x0;
+                }
             }
-
             break;
         }
         case InteractionState::OVER: {
@@ -498,7 +500,7 @@ void InteractOperation::tick() {
                 // We directly set the transition state as we want to move as fast as possible
                 // and we don't mind anymore about the relative position to the mast
                 desired_offset.x = 2;   //forward
-                desired_offset.y = 0.03;    //left
+                desired_offset.y = DIST_FH_DRONE_CENTRE_Y;    //left
                 desired_offset.z = DIST_FH_DRONE_CENTRE_Z;   //up
                 transition_state.state.position = desired_offset;
                 transition_state.cte_acc = MAX_ACCEL*3;
@@ -535,7 +537,7 @@ void InteractOperation::tick() {
                             << ": " << "Exit -> Extracted");
                     interaction_state = InteractionState::EXTRACTED;
                     desired_offset.x = 4;
-                    desired_offset.y = 0.03;
+                    desired_offset.y = DIST_FH_DRONE_CENTRE_Y;
                     desired_offset.z = 3;
                     transition_state.cte_acc = MAX_ACCEL*3;
                     transition_state.max_vel = MAX_VEL*3;
@@ -549,7 +551,7 @@ void InteractOperation::tick() {
                     for(int i = 0; i<3 ; i ++) interact_fail_pub.publish(number_fail);
                     interaction_state = InteractionState::APPROACHING;
                     desired_offset.x = 2;
-                    desired_offset.y = 0.03;
+                    desired_offset.y = DIST_FH_DRONE_CENTRE_Y;
                     desired_offset.z = DIST_FH_DRONE_CENTRE_Z+0.03;
                     transition_state.cte_acc = MAX_ACCEL;
                     transition_state.max_vel = MAX_VEL;

--- a/src/operations/interact_operation.cpp
+++ b/src/operations/interact_operation.cpp
@@ -256,7 +256,7 @@ void InteractOperation::update_attitude_input(mavros_msgs::PositionTarget offset
 
     accel_target = LQR_to_acceleration(ref);
     attitude_setpoint.orientation = accel_to_orientation(accel_target);
-    if(SHOW_PRINTS & time_cout%rate_int==0){
+    if(SHOW_PRINTS && (time_cout%rate_int)==0){
         printf("ref pose\tx %f,\ty %f,\tz %f\n",ref.position.x,
                             ref.position.y, ref.position.z);
     }

--- a/src/operations/land_operation.cpp
+++ b/src/operations/land_operation.cpp
@@ -9,7 +9,7 @@
 LandOperation::LandOperation() : Operation(OperationIdentifier::LAND, true, true) {}
 
 bool LandOperation::isBelowThreshold() const {
-    return getCurrentPose().pose.position.z < 0.40 &&
+    return getCurrentPose().pose.position.z < 0.05 &&
            std::abs(getCurrentTwist().twist.linear.z) <
                Fluid::getInstance().configuration.velocity_completion_threshold;
 }


### PR DESCRIPTION
Interact timing should largely be improved so that the interaction occurs when the mast is leaning frontward (i.e. in the /* position).
The detection of min and max pitch is not perfect, so it may still be some bugs from time to time, but it should work most of the time 